### PR TITLE
Bump go to 1.20, address deprecations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
                 }
             }
             steps {
-                goreleaser snapshot: true
+                goreleaser goVersion: '1.20.5', snapshot: true
                 archiveArtifacts artifacts: 'dist/*.zip', fingerprint: true
             }
         }

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,5 +1,6 @@
 FROM jenkins/jenkins:lts
 
-RUN /usr/local/bin/install-plugins.sh hashicorp-vault-plugin cloudbees-folder pipeline-model-definition git matrix-auth
+RUN jenkins-plugin-cli --plugins \
+    hashicorp-vault-plugin cloudbees-folder pipeline-model-definition git matrix-auth
 
 HEALTHCHECK --interval=4s --start-period=5s --retries=30 CMD [ "curl", "-f", "http://localhost:8080" ]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kingsoftgames/terraform-provider-jenkins
 
-go 1.18
+go 1.20
 
 require (
 	github.com/bndr/gojenkins v1.1.1-0.20210407143218-9e2483ff7ebd

--- a/jenkins/config.go
+++ b/jenkins/config.go
@@ -3,7 +3,6 @@ package jenkins
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	jenkins "github.com/bndr/gojenkins"
@@ -34,7 +33,7 @@ func newJenkinsClient(c *Config) *jenkinsAdapter {
 	client := jenkins.CreateJenkins(nil, c.ServerURL, c.Username, c.Password)
 	if c.CACert != nil {
 		// provide CA certificate if server is using self-signed certificate
-		client.Requester.CACert, _ = ioutil.ReadAll(c.CACert)
+		client.Requester.CACert, _ = io.ReadAll(c.CACert)
 	}
 
 	// return the Jenkins API client

--- a/makefile
+++ b/makefile
@@ -23,11 +23,11 @@ test:
 
 # Executes all acceptance tests for the provider
 testacc:
-	@docker-compose build
-	@docker-compose up -d --force-recreate jenkins
+	@docker compose build
+	@docker compose up -d --force-recreate jenkins
 	@while [ "$$(docker inspect jenkins-provider-acc --format '{{ .State.Health.Status }}')" != "healthy" ]; do echo "Waiting for Jenkins to start..."; sleep 3; done
 	TF_ACC=1 JENKINS_URL="http://localhost:8080" JENKINS_USERNAME="admin" JENKINS_PASSWORD="admin" go test -v -cover ./...
-	@docker-compose down
+	@docker compose down
 
 # Cleans up any lingering items in your system created by this provider.
 clean:


### PR DESCRIPTION
- Bump Go to 1.20.
- Addressing a deprecation of the io/ioutil Go standard library.
- Addressing the removal of the Jenkins install-plugins.sh file in favor of the [jenkins-plugin-cli command](https://github.com/jenkinsci/docker/blob/master/README.md#preinstalling-plugins).
- Use docker compose instead of deprecated docker-compose.